### PR TITLE
PG-1121 kubeconfig-injector trait

### DIFF
--- a/traitdefinitions/kubeconfig-injector.yaml
+++ b/traitdefinitions/kubeconfig-injector.yaml
@@ -1,0 +1,68 @@
+
+apiVersion: core.oam.dev/v1beta1
+kind: TraitDefinition
+metadata:
+  annotations:
+    definition.oam.dev/description: Inject the kubeconfig file to allow access with the kubectl command.
+  labels:
+    custom.definition.oam.dev/ui-hidden: "true"
+  name: kubeconfig-injector
+  namespace: vela-system
+spec:
+  appliesToWorkloads:
+    - deployments.apps
+  podDisruptive: true
+  schematic:
+    cue:
+      template: |
+        patch: spec: template: spec: {
+        	// +patchKey=name
+        	containers: [{
+        		name: context.name
+            env:[{
+              name: "KUBECONFIG"
+              value: "/var/napptive/kubeconfig"
+            }]
+        		// +patchKey=name
+        		volumeMounts: [{
+        			name:      parameter.mountName
+        			mountPath: "/var/napptive"
+        		}]
+        	}]
+        	initContainers: [{
+        		name:  parameter.name
+        		image: "napptive/kubeconfig-injector:latest"
+                imagePullPolicy: "Always"
+        		// +patchKey=name
+        		volumeMounts: [{
+        			name:      parameter.mountName
+        			mountPath: "/var/napptive"
+        		},{
+              name: parameter.saMountName
+              mountPath: "/var/run/secrets/kubernetes.io/serviceaccount"
+            }]
+        	}]
+        	// +patchKey=name
+        	volumes: [{
+        		name: parameter.mountName
+        		emptyDir: {}
+        	},{
+            name: parameter.saMountName
+            secret: {
+              secretName: "user-secret"
+              optional: false
+            },
+          }]
+        }
+        parameter: {
+        	// +usage=Specify the name of init container
+        	name: string
+
+        	// +usage=Specify the mount name of shared volume
+        	mountName: *"kubeconfig" | string
+
+        	// +usage=Specify the mount name of secret volume
+        	saMountName: *"sa-volume" | string
+        
+        }
+


### PR DESCRIPTION
New trait to inject kubeconfig file. This trait adds an init-container to generate the kube-config file from the user-secret mounted