### PR TITLE
Remove name parameter and fix the image

### DIFF
--- a/traitdefinitions/kubeconfig-injector.yaml
+++ b/traitdefinitions/kubeconfig-injector.yaml
@@ -31,7 +31,7 @@ spec:
         	}]
           // +patchKey=name
         	initContainers: [{
-        		name:  context.name + "kubecnf"
+        		name:  context.name + "-kubecnf"
         		image: "napptive/kubeconfig-injector:v1.0.0"
                 imagePullPolicy: "Always"
         		// +patchKey=name


### PR DESCRIPTION
Remove name parameter and fix the image

application for testing purposes (two components with kubeconfig-injector traits)

```yaml
apiVersion: core.oam.dev/v1beta1
kind: Application
metadata:
  name: first-vela-app-as-webservice
spec:
  components:
    - name: comp1
      type: webservice
      properties:
        image: crccheck/hello-world
        ports:
          - port: 8000
            expose: true
      traits:
      - type: kubeconfig-injector
        properties:
          mountName: "kubectlvolume"
          saMountName: "savolume"
    - name: comp2
      type: webservice
      properties:
        image: crccheck/hello-world
        ports:
          - port: 8000
            expose: true
      traits:
        - type: kubeconfig-injector
          properties:
            mountName: "kubectlvolume"
            saMountName: "savolume"
```