### PR TITLE
fix a bug in storage trait

### DIFF
--- a/traitdefinitions/storage.yaml
+++ b/traitdefinitions/storage.yaml
@@ -175,18 +175,24 @@ spec:
         	},
         ]
         patch: spec: template: spec: {
-        	// +patchKey=name
-        	volumes: deDupVolumesArray
+        	if len(deDupVolumesArray) != 0 {
+        	  // +patchKey=name
+        	  volumes: deDupVolumesArray
+            }
 
         	containers: [{
         		if len(configMapEnvMountsList + secretEnvMountsList + configMountToEnvsList + secretMountToEnvsList) != 0 {
         			// +patchKey=name
         			env: configMapEnvMountsList + secretEnvMountsList + configMountToEnvsList + secretMountToEnvsList
         		}
-        		// +patchKey=name
-        		volumeDevices: volumeDevicesList
-        		// +patchKey=name
-        		volumeMounts: pvcVolumeMountsList + configMapVolumeMountsList + secretVolumeMountsList + emptyDirVolumeMountsList
+                if len(volumeDevicesList) != 0 {
+        		   // +patchKey=name
+        		   volumeDevices: volumeDevicesList
+                 }
+                if len(pvcVolumeMountsList + configMapVolumeMountsList + secretVolumeMountsList + emptyDirVolumeMountsList) != 0 {
+             	   // +patchKey=name
+        		   volumeMounts: pvcVolumeMountsList + configMapVolumeMountsList + secretVolumeMountsList + emptyDirVolumeMountsList
+                }
         	}, ...]
 
         }


### PR DESCRIPTION
The trait fails when the component has a volume defined.

Application definition:
```yaml
apiVersion: core.oam.dev/v1beta1
kind: Application
metadata:
  name: err
  annotations:
    version: "8.0"
    description: "config error"
spec:
  components:
    - name: err
      type: webservice
      properties:
        image: mysql:8.0
        ports:
        - port: 3306
          expose: true
        volumeMounts:
          emptyDir:
          - name: data
            mountPath: "/var/lib/mysql"
      traits:
        - type: storage # Set to storage
          properties:
            secret: # Secret type storage
            - name: mysql-secret
              mountOnly: false
              mountToEnv:  # mount to Environment variables
                envName: MYSQL_ROOT_PASSWORD
                secretKey: password
              data:
                password: cGFzcw==
```

* Deploying with the installed trait:
```bash
$ playground apps deploy examples/storage_example.yaml
rpc error: code = Internal desc = error creating entity [Application "err"]: admission webhook "validating.core.oam.dev.v1beta1.applications" denied the request: field "schematic": Invalid value error encountered, cannot evaluate trait "storage": invalid patch trait storage into workload: result check err: spec.template.spec.volumes: conflicting list lengths: invalid value 0 (out of bound int & >=1).
```

* Deploying with the new one:
```bash
$ playground apps deploy examples/storage_example.yaml
Target environment: cdelope/test
STATUS     INFO
SUCCESS    application app deployed successfully
```

```bash
$ k --kubeconfig ~/.napptive/amazon/napptive-kubeconfig get po
NAME                 READY   STATUS    RESTARTS   AGE
app-6f98f4b8-th6cg   1/1     Running   0          2m59s
```

```bash
$ playground k8s secret
Target environment: cdelope/test

NAME            CREATION_TIME                    DATA
mysql-secret    2023-02-02 09:01:40 +0000 UTC    1
```