### PR TITLE
PS-9 Make the statefulservice rely on the headless service

### DIFF
--- a/componentdefintions/statefulservice.yaml
+++ b/componentdefintions/statefulservice.yaml
@@ -133,7 +133,7 @@ spec:
           }
         	spec: {
         		selector: matchLabels: app: context.name
-            serviceName: context.name  
+            serviceName: context.name + "-headless" 
             replicas: parameter.replicas          
         		template: {
         			metadata: {


### PR DESCRIPTION
This PR modifies the statefulservice definition so that the `serviceName` uses the headless service associated with the StatefulSet. For more information about stateful set, check the [official docs](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#components).