### PR TITLE
Feature/PG-1494 env from trait

### DIFF
--- a/trait/env-from.yaml
+++ b/trait/env-from.yaml
@@ -2,7 +2,7 @@ apiVersion: core.oam.dev/v1beta1
 kind: TraitDefinition
 metadata:
   annotations:
-    definition.oam.dev/description: Mount a configmap as environment variables of a component
+    definition.oam.dev/description: Mount configmaps/secrets as environment variables of a component
   labels:
     custom.definition.oam.dev/ui-hidden: "true"
   namespace: vela-system

--- a/trait/env-from.yaml
+++ b/trait/env-from.yaml
@@ -1,0 +1,60 @@
+apiVersion: core.oam.dev/v1beta1
+kind: TraitDefinition
+metadata:
+  annotations:
+    definition.oam.dev/description: Mount a configmap as environment variables of a component
+  labels:
+    custom.definition.oam.dev/ui-hidden: "true"
+  name: env-from
+spec:
+  appliesToWorkloads:
+    - deployments.apps
+    - statefulsets.apps
+    - jobs.batch
+  podDisruptive: true
+  schematic:
+    cue:
+      template: |
+        envFromCM: *[
+          for k, v in parameter.configmapName {
+          {
+            configMapRef:{
+              name: v
+            }          
+          }
+          },
+        ] | []
+        envFromSecret: *[
+          for k, v in parameter.secretName {
+          {
+            secretRef:{
+              name: v
+            }          
+          }
+          },
+        ] | []
+        patch: {
+          spec: template: spec: {
+            // +patchKey=name
+            containers: [{
+              if parameter.containerName != _|_ {
+        		name: parameter.containerName
+        	  }
+              if parameter.containerName == _|_ {
+        		name: context.name
+        	  }
+              envFrom: envFromCM + envFromSecret
+            }]
+          }
+        } 
+        parameter: {
+            // +usage=Specify the name of the target container, if not set, use the component name
+            containerName?: string
+        
+            // +usage=Specify the name of the configmap to be mounted as env vars
+        	configmapName?: [...string]
+
+        	// +usage=Specify the name of the secret to be mounted as env vars
+        	secretName?: [...string]
+        
+        }

--- a/trait/env-from.yaml
+++ b/trait/env-from.yaml
@@ -5,6 +5,7 @@ metadata:
     definition.oam.dev/description: Mount a configmap as environment variables of a component
   labels:
     custom.definition.oam.dev/ui-hidden: "true"
+  namespace: vela-system
   name: env-from
 spec:
   appliesToWorkloads:


### PR DESCRIPTION
Adds a new Trait `env-from` that mounts ConfigMaps or Secrets as environment variables of a component 

## Deploy the following application

```bash
apiVersion: core.oam.dev/v1beta1
kind: Application
metadata:
  name: postgresql
  annotations:
    version: v1.0.0
    description: "Postgres Database"
spec:
  components:
    - name: postgres-required
      type: k8s-objects # Set to k8s-objects
      properties:
        objects:
          # set the k8s manifest
          # Secret
          - apiVersion: v1
            kind: Secret
            metadata:
              name: postgres-secret
            type: Opaque
            data:
              POSTGRES_PASSWORD: cGFzc3dvcmQ=
              POSTGRES_USER: dXNlcg==
          # ConfigMap
          - apiVersion: v1
            kind: ConfigMap
            metadata:
              name: postgres-cm
            data:
              POSTGRES_DB: db
    - name: postgres
      type: webservice
      dependsOn:
        - postgres-required
      properties:
        image: postgres:13-alpine
        cpu: "150m"
        memory: 256Mi
        ports:
          - port: 5432
            expose: true
        env:
          - name: PGDATA
            value: "/var/lib/postgresql/data/pgdata"
        volumeMounts:
          emptyDir:
            - name: data
              mountPath: "/var/lib/postgresql/data"
      traits:
      - type: env-from
        properties:
          configmapName:
            - postgres-cm
          secretName:
            - postgres-secret
```
